### PR TITLE
feat(docker): label all containers/volumes, own the floci-oci- prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **docker:** every emulator-created container and volume is now labelled `floci=true` and `floci_emulator=floci-oci` (plus `floci_namespace` when `FLOCI_OCI_DOCKER_RESOURCE_NAMESPACE` is set), so one emulator's resources can be filtered or pruned without touching sibling Floci emulators on the same Docker host: `docker volume prune --filter label=floci_emulator=floci-oci`
+- **docs:** documented `FLOCI_OCI_DOCKER_RESOURCE_NAMESPACE`
+
+### Changed
+
+- **docker:** the `floci-oci-` container/volume name prefix is now owned by `ContainerStorageHelper` instead of being spelled at call sites. Default names are unchanged (`floci-oci-fnserver`); with a resource namespace configured, the namespace now lands after the cloud token (`floci-oci-<ns>-fnserver`, previously `floci-<ns>-oci-fnserver`). If you run namespaced instances, remove orphaned containers from earlier versions with `docker rm -f $(docker ps -aq --filter name=^/floci-)`
+
 ## [0.1.0] - 2026-07-27
 
 Initial release. floci-oci emulates seven Oracle Cloud Infrastructure services on a

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -29,6 +29,7 @@ All configuration lives under the `floci-oci.*` prefix; every property maps to a
 | `FLOCI_OCI_SERVICES_FUNCTIONS_MOCK` | `false` | Skip the Fn sidecar; invocations return a synthetic body |
 | `FLOCI_OCI_SERVICES_FUNCTIONS_SERVER_IMAGE` | `fnproject/fnserver:latest` | Fn Project server image |
 | `FLOCI_OCI_SERVICES_DOCKER_NETWORK` | – | Shared Docker network for sidecar containers |
+| `FLOCI_OCI_DOCKER_RESOURCE_NAMESPACE` | – | Namespace inserted into sidecar container/volume names (`floci-oci-<ns>-…`) so parallel emulator instances on one Docker host don't collide |
 
 Per-service storage overrides use the map form:
 

--- a/src/main/java/io/floci/oci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/floci/oci/core/common/docker/ContainerBuilder.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +25,7 @@ import java.util.Optional;
  * <p>Example usage:
  * <pre>{@code
  * ContainerSpec spec = containerBuilder.newContainer("nginx:latest")
- *     .withName("floci-my-service")
+ *     .withName(ContainerStorageHelper.dockerName(config, "my-service"))
  *     .withEnv("MY_VAR", "value")
  *     .withDynamicPort(8080)
  *     .withDockerNetwork(config.services().myService().dockerNetwork())
@@ -126,6 +127,7 @@ public class ContainerBuilder {
         private String user;
         private final List<String> groupAdd = new ArrayList<>();
         private final List<String> dnsServers = new ArrayList<>();
+        private final Map<String, String> labels = new LinkedHashMap<>();
 
         Builder(String image, EmulatorConfig config, DockerHostResolver dockerHostResolver,
                 EmbeddedDnsServer embeddedDnsServer,
@@ -387,6 +389,22 @@ public class ContainerBuilder {
         }
 
         /**
+         * Adds a single Docker label. Merged over the emulator default labels at create time.
+         */
+        public Builder withLabel(String key, String value) {
+            this.labels.put(key, value);
+            return this;
+        }
+
+        /**
+         * Adds multiple Docker labels. Merged over the emulator default labels at create time.
+         */
+        public Builder withLabels(Map<String, String> labels) {
+            this.labels.putAll(labels);
+            return this;
+        }
+
+        /**
          * Injects Floci's embedded DNS server into the container so virtual-hosted
          * S3 hostnames (my-bucket.localhost.floci.io) resolve to Floci's Docker
          * network IP. No-op when the embedded DNS server is not running.
@@ -432,7 +450,8 @@ public class ContainerBuilder {
                     List.copyOf(dnsServers),
                     workingDir,
                     user,
-                    List.copyOf(groupAdd)
+                    List.copyOf(groupAdd),
+                    Map.copyOf(labels)
             );
         }
     }

--- a/src/main/java/io/floci/oci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/oci/core/common/docker/ContainerLifecycleManager.java
@@ -15,6 +15,7 @@ import com.github.dockerjava.api.model.Mount;
 import com.github.dockerjava.api.model.MountType;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
+import io.floci.oci.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -41,6 +42,7 @@ public class ContainerLifecycleManager {
     private final ImageCacheService imageCacheService;
     private final ContainerDetector containerDetector;
     private final PortAllocator portAllocator;
+    private final EmulatorConfig config;
 
     /** Volumes whose shared-ownership root has already been initialised this process (run-once guard). */
     private final ConcurrentHashMap<String, Boolean> initializedSharedVolumes = new ConcurrentHashMap<>();
@@ -49,11 +51,13 @@ public class ContainerLifecycleManager {
     public ContainerLifecycleManager(DockerClient dockerClient,
                                      ImageCacheService imageCacheService,
                                      ContainerDetector containerDetector,
-                                     PortAllocator portAllocator) {
+                                     PortAllocator portAllocator,
+                                     EmulatorConfig config) {
         this.dockerClient = dockerClient;
         this.imageCacheService = imageCacheService;
         this.containerDetector = containerDetector;
         this.portAllocator = portAllocator;
+        this.config = config;
     }
 
     /**
@@ -98,6 +102,7 @@ public class ContainerLifecycleManager {
         if (spec.name() != null) {
             createCmd.withName(spec.name());
         }
+        createCmd.withLabels(mergedLabels(spec.labels()));
         if (spec.user() != null && !spec.user().isBlank()) {
             createCmd.withUser(spec.user());
         }
@@ -195,17 +200,27 @@ public class ContainerLifecycleManager {
 
     /**
      * Creates a named volume if it does not already exist. Idempotent — safe to call on every
-     * container start. Labels the volume {@code floci=true} so
-     * {@code docker volume prune --filter label=floci} works.
+     * container start. Labels the volume {@code floci=true} and
+     * {@code floci_emulator=floci-oci} so both
+     * {@code docker volume prune --filter label=floci=true} (all emulators) and
+     * {@code --filter label=floci_emulator=floci-oci} (this emulator only) work.
      */
     public void ensureVolume(String volumeName) {
         if (!volumeExists(volumeName)) {
             dockerClient.createVolumeCmd()
                     .withName(volumeName)
-                    .withLabels(Map.of("floci", "true"))
+                    .withLabels(ContainerStorageHelper.defaultLabels(config))
                     .exec();
             LOG.debugv("Created volume {0}", volumeName);
         }
+    }
+
+    private Map<String, String> mergedLabels(Map<String, String> specLabels) {
+        Map<String, String> labels = ContainerStorageHelper.defaultLabels(config);
+        if (specLabels != null) {
+            labels.putAll(specLabels);
+        }
+        return labels;
     }
 
     /**
@@ -286,6 +301,7 @@ public class ContainerLifecycleManager {
         CreateContainerResponse created = dockerClient.createContainerCmd(image)
                 .withHostConfig(hostConfig)
                 .withCmd("sh", "-c", script.toString())
+                .withLabels(ContainerStorageHelper.defaultLabels(config))
                 .exec();
         String helperId = created.getId();
         try {

--- a/src/main/java/io/floci/oci/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/floci/oci/core/common/docker/ContainerSpec.java
@@ -30,6 +30,7 @@ import java.util.Map;
  * @param workingDir Working directory inside the container (overrides image WORKDIR)
  * @param user User the container process runs as, formatted "uid[:gid]" (null = image USER)
  * @param groupAdd Supplementary group IDs added to the container process
+ * @param labels Docker labels applied to the container, merged over the emulator defaults
  */
 public record ContainerSpec(
         String image,
@@ -50,14 +51,15 @@ public record ContainerSpec(
         List<String> dnsServers,
         String workingDir,
         String user,
-        List<String> groupAdd
+        List<String> groupAdd,
+        Map<String, String> labels
 ) {
     /**
      * Creates a minimal spec with just the image name.
      * All other fields will be null or empty lists.
      */
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), null, false, null, List.of(), null, null, List.of());
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), null, false, null, List.of(), null, null, List.of(), Map.of());
     }
 
     /**

--- a/src/main/java/io/floci/oci/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/floci/oci/core/common/docker/ContainerStorageHelper.java
@@ -6,14 +6,22 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * Central helper for child-container volume management across RDS, OpenSearch, MSK, and ECR.
+ * Central helper for naming and labelling emulator-managed Docker containers and volumes,
+ * and for child-container volume management.
  *
- * <p>Two modes:
+ * <p>Every emulator-created resource is named {@code floci-oci-[<namespace>-]<service>[-<id>]}
+ * and labelled {@code floci=true} plus {@code floci_emulator=floci-oci} so it is attributable
+ * to this emulator by name and by label. The prefix is owned here — call sites pass bare
+ * service tokens, never the prefix.
+ *
+ * <p>Volume storage modes:
  * <ul>
- *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes labelled
- *       {@code floci=true}. Active when {@code FLOCI_STORAGE_HOST_PERSISTENT_PATH} is not set.</li>
+ *   <li>Named-volume (default) — Floci manages per-resource Docker named volumes.
+ *       Active when {@code FLOCI_STORAGE_HOST_PERSISTENT_PATH} is not set.</li>
  *   <li>Host-path (legacy) — active when {@code FLOCI_STORAGE_HOST_PERSISTENT_PATH} is set;
  *       callers fall through to their existing bind-mount logic.</li>
  * </ul>
@@ -21,6 +29,10 @@ import java.nio.file.Path;
 public final class ContainerStorageHelper {
 
     private static final Logger LOG = Logger.getLogger(ContainerStorageHelper.class);
+
+    static final String CLOUD = "oci";
+    static final String CONTAINER_PREFIX = "floci-" + CLOUD + "-";
+    static final String LEGACY_PREFIX = "floci-";
 
     private ContainerStorageHelper() {}
 
@@ -34,18 +46,48 @@ public final class ContainerStorageHelper {
     }
 
     public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
-        return dockerName(config, "floci-" + service + "-" + (volumeId != null ? volumeId : fallbackId));
+        return dockerName(config, service + "-" + (volumeId != null ? volumeId : fallbackId));
     }
 
+    /**
+     * Prefixes {@code baseName} with {@code floci-oci-} and the configured resource namespace.
+     * Accepts already-prefixed names (current or legacy {@code floci-} prefix) and normalises
+     * them, so the namespace always lands between the cloud token and the service token.
+     */
     public static String dockerName(EmulatorConfig config, String baseName) {
+        String base = stripPrefix(baseName);
         String namespace = resourceNamespace(config);
         if (namespace.isBlank()) {
-            return baseName;
+            return CONTAINER_PREFIX + base;
         }
-        if (baseName.startsWith("floci-")) {
-            return "floci-" + namespace + "-" + baseName.substring("floci-".length());
+        return CONTAINER_PREFIX + namespace + "-" + base;
+    }
+
+    /**
+     * Labels applied to every emulator-created container and volume:
+     * {@code floci=true} (umbrella across all Floci emulators),
+     * {@code floci_emulator=floci-oci} (per-emulator discriminator), and
+     * {@code floci_namespace} when a resource namespace is configured.
+     */
+    public static Map<String, String> defaultLabels(EmulatorConfig config) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci", "true");
+        labels.put("floci_emulator", "floci-" + CLOUD);
+        String namespace = resourceNamespace(config);
+        if (!namespace.isBlank()) {
+            labels.put("floci_namespace", namespace);
         }
-        return "floci-" + namespace + "-" + baseName;
+        return labels;
+    }
+
+    private static String stripPrefix(String baseName) {
+        if (baseName.startsWith(CONTAINER_PREFIX)) {
+            return baseName.substring(CONTAINER_PREFIX.length());
+        }
+        if (baseName.startsWith(LEGACY_PREFIX)) {
+            return baseName.substring(LEGACY_PREFIX.length());
+        }
+        return baseName;
     }
 
     public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {

--- a/src/main/java/io/floci/oci/services/functions/FnServerManager.java
+++ b/src/main/java/io/floci/oci/services/functions/FnServerManager.java
@@ -67,7 +67,7 @@ public class FnServerManager {
             LOG.warn("fnserver container died — restarting");
             stop();
         }
-        String name = ContainerStorageHelper.dockerName(config, "floci-oci-fnserver");
+        String name = ContainerStorageHelper.dockerName(config, "fnserver");
         lifecycleManager.removeIfExists(name);
         int port = portAllocator.allocate(
                 config.services().functions().serverBasePort(),
@@ -90,6 +90,7 @@ public class FnServerManager {
                 .withNamedVolume(iofsVolume, "/iofs")
                 .withDockerNetwork(config.services().dockerNetwork())
                 .withLogRotation()
+                .withLabel("floci_service", "functions")
                 .build();
         ContainerLifecycleManager.ContainerInfo info = lifecycleManager.createAndStart(spec);
         containerId = info.containerId();
@@ -131,7 +132,7 @@ public class FnServerManager {
             try {
                 lifecycleManager.stopAndRemove(containerId, null);
                 lifecycleManager.removeVolume(
-                        ContainerStorageHelper.dockerName(config, "floci-oci-fnserver") + "-iofs");
+                        ContainerStorageHelper.dockerName(config, "fnserver") + "-iofs");
             } catch (Exception e) {
                 LOG.warnv("Failed to stop fnserver container: {0}", e.getMessage());
             }

--- a/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -1,0 +1,137 @@
+package io.floci.oci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+import io.floci.oci.config.EmulatorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Every emulator-created container and volume must carry the shared Floci labels
+ * ({@code floci=true}, {@code floci_emulator=floci-oci}, and {@code floci_namespace}
+ * when configured) so a single Docker host running several Floci emulators can be
+ * pruned per emulator. Asserting at the {@link ContainerLifecycleManager} choke point
+ * covers every service by construction.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContainerLifecycleManagerLabelsTest {
+
+    @Mock
+    private DockerClient dockerClient;
+
+    @Mock
+    private ImageCacheService imageCacheService;
+
+    @Mock
+    private ContainerDetector containerDetector;
+
+    @Mock
+    private PortAllocator portAllocator;
+
+    @Mock
+    private EmulatorConfig config;
+
+    @Mock
+    private EmulatorConfig.DockerConfig dockerConfig;
+
+    private ContainerLifecycleManager manager;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(config.docker()).thenReturn(dockerConfig);
+        lenient().when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+        manager = new ContainerLifecycleManager(dockerClient, imageCacheService, containerDetector, portAllocator, config);
+    }
+
+    @Test
+    void createAppliesDefaultLabelsToEveryContainer() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager.create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createMergesSpecLabelsOverDefaults() {
+        lenient().when(dockerConfig.imageRegistryBase()).thenReturn(Optional.empty());
+        CreateContainerCmd createCmd = stubCreateContainer();
+        ContainerSpec spec = new ContainerBuilder(config, mock(DockerHostResolver.class), null)
+                .newContainer("busybox:stable")
+                .withLabel("floci_service", "functions")
+                .build();
+
+        manager.create(spec);
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci", "floci_service", "functions"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createIncludesNamespaceLabelWhenConfigured() {
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager.create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci", "floci_namespace", "run-one"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void ensureVolumeAppliesTheSameDefaultLabels() {
+        InspectVolumeCmd inspectCmd = mock(InspectVolumeCmd.class);
+        when(dockerClient.inspectVolumeCmd("floci-oci-fnserver-iofs")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenThrow(new NotFoundException("No such volume"));
+        CreateVolumeCmd createVolumeCmd = mock(CreateVolumeCmd.class, RETURNS_SELF);
+        when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
+
+        manager.ensureVolume("floci-oci-fnserver-iofs");
+
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createVolumeCmd).withLabels(labels.capture());
+        assertEquals(Map.of("floci", "true", "floci_emulator", "floci-oci"), labels.getValue());
+    }
+
+    private CreateContainerCmd stubCreateContainer() {
+        CreateContainerCmd createCmd = mock(CreateContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.createContainerCmd("busybox:stable")).thenReturn(createCmd);
+        CreateContainerResponse response = mock(CreateContainerResponse.class);
+        when(response.getId()).thenReturn("container-id");
+        when(createCmd.exec()).thenReturn(response);
+        return createCmd;
+    }
+
+    private Map<String, String> capturedLabels(CreateContainerCmd createCmd) {
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createCmd).withLabels(labels.capture());
+        return labels.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArgumentCaptor<Map<String, String>> labelsCaptor() {
+        return ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+    }
+}

--- a/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
+++ b/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
@@ -2,6 +2,7 @@ package io.floci.oci.core.common.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.RemoveContainerCmd;
+import io.floci.oci.config.EmulatorConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,13 +43,16 @@ class ContainerLifecycleManagerStartFailureTest {
     @Mock
     private PortAllocator portAllocator;
 
+    @Mock
+    private EmulatorConfig config;
+
     private ContainerLifecycleManager manager;
     private final ContainerSpec spec = new ContainerSpec("busybox:latest");
 
     @BeforeEach
     void setUp() {
         manager = spy(new ContainerLifecycleManager(
-                dockerClient, imageCacheService, containerDetector, portAllocator));
+                dockerClient, imageCacheService, containerDetector, portAllocator, config));
     }
 
     @Test

--- a/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerVolumeTest.java
+++ b/src/test/java/io/floci/oci/core/common/docker/ContainerLifecycleManagerVolumeTest.java
@@ -11,6 +11,7 @@ import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
+import io.floci.oci.config.EmulatorConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,11 +39,14 @@ class ContainerLifecycleManagerVolumeTest {
     @Mock
     private PortAllocator portAllocator;
 
+    @Mock
+    private EmulatorConfig config;
+
     private ContainerLifecycleManager manager;
 
     @BeforeEach
     void setUp() {
-        manager = new ContainerLifecycleManager(dockerClient, imageCacheService, containerDetector, portAllocator);
+        manager = new ContainerLifecycleManager(dockerClient, imageCacheService, containerDetector, portAllocator, config);
     }
 
     @Test

--- a/src/test/java/io/floci/oci/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/floci/oci/core/common/docker/ContainerStorageHelperTest.java
@@ -4,6 +4,7 @@ import io.floci.oci.config.EmulatorConfig;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,36 +14,58 @@ import static org.mockito.Mockito.when;
 class ContainerStorageHelperTest {
 
     @Test
-    void resourceNamesStayUnchangedWithoutNamespace() {
-        assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName("rds", null, "db1"));
-        assertEquals("floci-rds-vol1", ContainerStorageHelper.resourceName(config(""), "rds", "vol1", "db1"));
-        assertEquals("floci-opensearch-domain1", ContainerStorageHelper.resourceName(config(""), "opensearch", null, "domain1"));
-        assertEquals("floci-ec2-i-123", ContainerStorageHelper.dockerName(config(""), "floci-ec2-i-123"));
+    void namesCarryTheOciPrefixWithoutNamespace() {
+        assertEquals("floci-oci-fnserver", ContainerStorageHelper.dockerName(config(""), "fnserver"));
+        assertEquals("floci-oci-fnserver-id1", ContainerStorageHelper.resourceName("fnserver", null, "id1"));
+        assertEquals("floci-oci-fnserver-vol1", ContainerStorageHelper.resourceName(config(""), "fnserver", "vol1", "id1"));
     }
 
     @Test
-    void resourceNamesIncludeSanitizedNamespaceWhenConfigured() {
+    void namespaceLandsBetweenCloudAndServiceTokens() {
         EmulatorConfig config = config(" run/one ");
 
-        assertEquals("floci-run-one-rds-db1", ContainerStorageHelper.resourceName(config, "rds", null, "db1"));
-        assertEquals("floci-run-one-rds-vol1", ContainerStorageHelper.resourceName(config, "rds", "vol1", "db1"));
-        assertEquals("floci-run-one-ec2-i-123", ContainerStorageHelper.dockerName(config, "floci-ec2-i-123"));
-        assertEquals("floci-run-one-ui", ContainerStorageHelper.dockerName(config, "floci-ui"));
+        assertEquals("floci-oci-run-one-fnserver", ContainerStorageHelper.dockerName(config, "fnserver"));
+        assertEquals("floci-oci-run-one-fnserver-id1", ContainerStorageHelper.resourceName(config, "fnserver", null, "id1"));
+        assertEquals("floci-oci-run-one-fnserver-vol1", ContainerStorageHelper.resourceName(config, "fnserver", "vol1", "id1"));
+    }
+
+    @Test
+    void alreadyPrefixedNamesAreNormalized() {
+        assertEquals("floci-oci-fnserver", ContainerStorageHelper.dockerName(config(""), "floci-oci-fnserver"));
+        assertEquals("floci-oci-fnserver", ContainerStorageHelper.dockerName(config(""), "floci-fnserver"));
+        assertEquals("floci-oci-run-one-fnserver", ContainerStorageHelper.dockerName(config("run-one"), "floci-oci-fnserver"));
+        assertEquals("floci-oci-run-one-fnserver", ContainerStorageHelper.dockerName(config("run-one"), "floci-fnserver"));
+    }
+
+    @Test
+    void defaultLabelsIdentifyThisEmulator() {
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci"),
+                ContainerStorageHelper.defaultLabels(config("")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci", "floci_namespace", "run-one"),
+                ContainerStorageHelper.defaultLabels(config(" run/one ")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci"),
+                ContainerStorageHelper.defaultLabels(null));
     }
 
     @Test
     void hostResourcePathsIncludeNamespaceWhenConfigured() {
         EmulatorConfig config = config("run-one");
 
-        assertEquals(Path.of("/tmp/floci/run-one/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
+        assertEquals(Path.of("/tmp/floci/run-one/fnserver/id1"), ContainerStorageHelper.hostResourcePath(config, "fnserver", "id1"));
     }
 
     @Test
     void unsafeNamespaceSegmentsAreIgnored() {
         EmulatorConfig config = config("..");
 
-        assertEquals(Path.of("/tmp/floci/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
-        assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName(config, "rds", null, "db1"));
+        assertEquals(Path.of("/tmp/floci/fnserver/id1"), ContainerStorageHelper.hostResourcePath(config, "fnserver", "id1"));
+        assertEquals("floci-oci-fnserver-id1", ContainerStorageHelper.resourceName(config, "fnserver", null, "id1"));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-oci"),
+                ContainerStorageHelper.defaultLabels(config));
     }
 
     private static EmulatorConfig config(String namespace) {


### PR DESCRIPTION
## Summary

Labels every emulator-created Docker container and volume with `floci=true`,
`floci_emulator=floci-oci`, and `floci_namespace` (when
`FLOCI_OCI_DOCKER_RESOURCE_NAMESPACE` is set), so one emulator's resources can
be filtered or pruned without touching sibling Floci emulators on the same
host — e.g. `docker volume prune --filter label=floci_emulator=floci-oci`.
`ContainerStorageHelper` now owns the `floci-oci-` name prefix; call sites
pass bare service tokens. Default names are unchanged; with a namespace
configured, it now lands after the cloud token (`floci-oci-<ns>-fnserver`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## OCI Compatibility

No wire-protocol impact — this touches only the sidecar container
infrastructure (naming and Docker labels), not any OCI API surface.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)