### PR TITLE
fix(tls): register BouncyCastle before the persisted-cert reuse check

### DIFF
--- a/src/main/java/io/floci/oci/config/TlsConfigSource.java
+++ b/src/main/java/io/floci/oci/config/TlsConfigSource.java
@@ -63,6 +63,13 @@ public class TlsConfigSource implements ConfigSource {
             return;
         }
 
+        // BouncyCastle may not be registered yet — this ConfigSource runs before CDI (@Startup beans)
+        // and before quarkus-security's runtime provider registration. Register it up front so BOTH
+        // certificate parsing (isSelfSigned/parseCertificate) and generation work; otherwise
+        // parseCertificate fails "no such provider: BC", isSelfSigned returns false, and the persisted
+        // self-signed certificate is needlessly regenerated on every restart.
+        ensureBouncyCastleRegistered();
+
         String certPath = resolveProperty("floci-oci.tls.cert-path", "");
         String keyPath = resolveProperty("floci-oci.tls.key-path", "");
         String selfSigned = resolveProperty("floci-oci.tls.self-signed", "true");
@@ -162,14 +169,16 @@ public class TlsConfigSource implements ConfigSource {
         return defaultValue;
     }
 
+    private static void ensureBouncyCastleRegistered() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
     private void generateSelfSignedCert(Path tlsDir, Path certFile, Path keyFile) {
         try {
             Files.createDirectories(tlsDir);
-
-            // BouncyCastle may not be registered yet — ConfigSource runs before CDI
-            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-                Security.addProvider(new BouncyCastleProvider());
-            }
+            ensureBouncyCastleRegistered();
 
             // Extract custom hostnames and combine with defaults
             List<String> customHostnames = extractCustomHostnames();


### PR DESCRIPTION
## Summary

`TlsConfigSource` runs before CDI and quarkus-security's runtime provider
registration, so certificate parsing failed with "no such provider: BC",
`isSelfSigned` returned false, and the persisted self-signed certificate was
needlessly regenerated on every restart. Registers the BouncyCastle provider
up front so both parsing and generation work. Ported from floci-aws a4356f25.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## OCI Compatibility

No wire-protocol impact. Incorrect behavior: the persisted self-signed TLS
certificate was regenerated on every emulator restart instead of being reused,
because provider-less parsing made the reuse check always fail.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — direct port of the fix already
  landed in floci-aws (a4356f25); the config source runs pre-CDI, which the
  Quarkus test harness doesn't exercise
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)