### PR TITLE
perf(docker): stop duplicating the native binary into a second image layer

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Stage native binary for packaging
         run: |
           mkdir -p native/arm64
-          cp target/*-runner native/arm64/
+          cp target/*-runner native/arm64/application
           cp target/*.so native/arm64/ 2>/dev/null || true
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,8 +129,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - name: Set created timestamp
         id: created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -63,10 +63,8 @@ ARG VERSION=latest
 ENV FLOCI_OCI_VERSION=${VERSION}
 ENV FLOCI_OCI_STORAGE_PERSISTENT_PATH=/app/data
 
-COPY --from=build /app/target/*-runner /app/application
+COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
-RUN chmod +x /app/application
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -34,8 +34,7 @@ RUN mkdir -p /app/data \
 
 VOLUME /app/data
 
-COPY --chown=1001:root native/${TARGETARCH}/ /app/
-RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 


### PR DESCRIPTION
## Summary

The native image published a second full copy of the ~196 MB binary: `RUN mv`/`chmod`
after `COPY` rewrites the whole file into a new layer. This sets the executable bit at
COPY time (`COPY --chmod=755`) and moves the rename into CI staging, which now places
the binary at `native/<arch>/application` before the docker build. Ports floci-aws
9e90e5cf, where the same change cut the image from 521 MB to 325 MB uncompressed.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

Performance (`perf:`) — image-size optimization, no behavior change.

## OCI Compatibility

Not applicable — packaging/CI only, nothing on the wire changes.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)