### PR TITLE
fix: prefix PARs (AnyObjectWrite/AnyObjectRead) always reject access

### DIFF
--- a/src/main/java/io/floci/oci/services/objectstorage/ParAccessController.java
+++ b/src/main/java/io/floci/oci/services/objectstorage/ParAccessController.java
@@ -30,6 +30,8 @@ public class ParAccessController {
             Set.of("ObjectRead", "ObjectReadWrite", "AnyObjectRead", "AnyObjectReadWrite");
     private static final Set<String> WRITE_TYPES =
             Set.of("ObjectWrite", "ObjectReadWrite", "AnyObjectWrite", "AnyObjectReadWrite");
+    private static final Set<String> PREFIX_TYPES =
+            Set.of("AnyObjectRead", "AnyObjectWrite", "AnyObjectReadWrite");
 
     private final ObjectStorageService service;
 
@@ -73,9 +75,13 @@ public class ParAccessController {
             throw OciException.notAuthorizedOrNotFound(
                     "The pre-authenticated request does not grant access to this bucket.");
         }
-        if (par.getObjectName() != null && !par.getObjectName().equals(objectName)) {
-            throw OciException.notAuthorizedOrNotFound(
-                    "The pre-authenticated request does not grant access to this object.");
+        if (par.getObjectName() != null) {
+            boolean isPrefixMatch = PREFIX_TYPES.contains(par.getAccessType())
+                    && objectName.startsWith(par.getObjectName());
+            if (!isPrefixMatch && !par.getObjectName().equals(objectName)) {
+                throw OciException.notAuthorizedOrNotFound(
+                        "The pre-authenticated request does not grant access to this object.");
+            }
         }
         if (!allowedTypes.contains(par.getAccessType())) {
             throw OciException.notAuthorizedOrNotFound(

--- a/src/test/java/io/floci/oci/services/objectstorage/ObjectStorageRestIntegrationTest.java
+++ b/src/test/java/io/floci/oci/services/objectstorage/ObjectStorageRestIntegrationTest.java
@@ -304,6 +304,40 @@ class ObjectStorageRestIntegrationTest {
     }
 
     @Test
+    void prefixPreauthenticatedRequestGrantsWriteUnderPrefix() {
+        String bucket = uniqueBucket("it-par-prefix");
+        createBucket(bucket);
+
+        String accessUri = given()
+                .contentType("application/json")
+                .body(Map.of("name", "uploads", "accessType", "AnyObjectWrite",
+                        "timeExpires", "2999-01-01T00:00:00Z", "objectName", "uploads/"))
+            .when().post("/n/" + NS + "/b/" + bucket + "/p")
+            .then().statusCode(200)
+                .body("accessUri", startsWith("/p/"))
+                .extract().path("accessUri");
+
+        // A prefix PAR must allow writes to any object name under that prefix.
+        given().contentType("text/plain").body("under-prefix")
+            .when().put(accessUri + "file.txt")
+            .then().statusCode(200);
+
+        given()
+            .when().get("/n/" + NS + "/b/" + bucket + "/o/uploads/file.txt")
+            .then().statusCode(200).body(equalTo("under-prefix"));
+
+        // Writes outside the granted prefix must still be rejected — same PAR token,
+        // an object name that does not start with "uploads/".
+        String parBasePath = accessUri.substring(0, accessUri.length() - "uploads/".length());
+        given().contentType("text/plain").body("outside-prefix")
+            .when().put(parBasePath + "other/file.txt")
+            .then().statusCode(404);
+
+        given().when().delete("/n/" + NS + "/b/" + bucket + "/o/uploads/file.txt").then().statusCode(204);
+        given().when().delete("/n/" + NS + "/b/" + bucket).then().statusCode(204);
+    }
+
+    @Test
     void listRetentionRulesAnswersEmptyCollection() {
         // Terraform's bucket Read calls ListRetentionRules unconditionally — a 404 here
         // makes the provider silently drop the bucket from state.


### PR DESCRIPTION
ParAccessController.authorize() compared the PAR's stored objectName against the request's objectName using strict equality, regardless of accessType. This is correct for ObjectRead/ObjectWrite/ObjectReadWrite (which target a single named object), but wrong for the Any* types, which the OCI API documents as prefix-scoped: a PAR created with accessType=AnyObjectWrite and objectName="uploads/" should permit writes to any object name starting with that prefix (e.g. "uploads/foo.txt"), not just literal equality with "uploads/" itself.

In practice this meant any prefix PAR could be created successfully via CreatePreauthenticatedRequest, but every subsequent read/write through it failed with 404 NotAuthorizedOrNotFound — the prefix PAR was accepted at creation time yet unusable for its documented purpose.

Fix: when accessType is one of AnyObjectRead/AnyObjectWrite/ AnyObjectReadWrite, accept objectName.startsWith(par.getObjectName()) in addition to exact equality. Exact-object access types are unaffected — they still require strict equality.

Added prefixPreauthenticatedRequestGrantsWriteUnderPrefix to ObjectStorageRestIntegrationTest, covering: write inside the granted prefix succeeds, the object is persisted and readable, and writes outside the prefix are still rejected with the same PAR token.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## OCI Compatibility

<!-- For new actions: which SDK version and OCI CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

