### PR TITLE
docs(readme): point the build badge at release.yml and add docker pulls/image-size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 <p align="center">
   <a href="https://github.com/floci-io/floci-oci/releases/latest"><img src="https://img.shields.io/github/v/release/floci-io/floci-oci?label=latest%20release&color=blue" alt="Latest Release"></a>
-  <a href="https://github.com/floci-io/floci-oci/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/floci-io/floci-oci/ci.yml?label=build" alt="Build Status"></a>
+  <a href="https://github.com/floci-io/floci-oci/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/floci-io/floci-oci/release.yml?label=build" alt="Build Status"></a>
+  <a href="https://hub.docker.com/r/floci/floci-oci"><img src="https://img.shields.io/docker/pulls/floci/floci-oci?label=docker%20pulls" alt="Docker Pulls"></a>
+  <a href="https://hub.docker.com/r/floci/floci-oci"><img src="https://img.shields.io/docker/image-size/floci/floci-oci/latest?label=image%20size" alt="Docker Image Size"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
   <a href="https://github.com/floci-io/floci-oci/stargazers"><img src="https://img.shields.io/github/stars/floci-io/floci-oci?style=flat" alt="GitHub Stars"></a>
 </p>


### PR DESCRIPTION
## Summary
Aligns the README badge row with floci-io/floci: the build badge now tracks `release.yml` (it was the only emulator on `ci.yml`), and Docker pulls + image size badges for `floci/floci-oci` are added. Six badges, same order as aws/gcp/az.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## OCI Compatibility

N/A — README only.

## Checklist

- [ ] `./mvnw test` passes locally — not run; README-only change. Gate used instead: all three changed shields.io URLs return HTTP 200.
- [ ] New or updated integration test added — N/A (docs)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_01DwuCcoFzgJT44GUHfUqgGP