### PR TITLE
ci: cache maven on main and warm compat images instead of writing per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,34 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-          cache: maven
+          # no `cache: maven` - broken in this action release line: it restores nothing
+          # ("maven cache is not found") and then fails to save ("Path Validation Error:
+          # Path(s) specified in the action for caching do(es) not exist"), so every run
+          # resolved dependencies cold. Explicit cache steps below do the same job.
+
+      # Restore on every run, save from main only. Actions caches are ref-scoped: a
+      # pull_request run's write lands in refs/pull/N/merge, which no other PR can read,
+      # so a PR save is a private duplicate of what main already publishes under this key.
+      # This job is the repo's single cache writer; compatibility.yml and nightly.yml
+      # restore the same key read-only.
+      #
+      # `hashFiles('pom.xml')`, not '**/pom.xml': the glob would also hash
+      # compatibility-tests/sdk-test-java/pom.xml, a project this workflow never builds,
+      # and an unrelated change there would bust the key.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
 
       - name: Run tests
         run: mvn test -B
+
+      # `on.push.branches` is [main] only in this workflow, so `push` means main.
+      # `always()` so a failed test run still saves the dependencies it resolved.
+      - uses: actions/cache/save@v6.1.0
+        if: always() && github.event_name == 'push'
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,8 +29,22 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` - it keys on setup-graalvm-Linux-maven-<hash>, a key only
+          # this pull_request-only workflow ever writes. Actions caches are ref-scoped, so
+          # those writes land in refs/pull/N/merge and no run can read another's: it misses
+          # every time while still saving hundreds of MB nothing will read.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, keyed identically to ci.yml so this reads the ~/.m2 that ci.yml saves
+      # on push to main. ci.yml stays the single writer; a second writer would race it.
+      # Partial-hit caveat: ci.yml runs x64 and this runs arm64, but `runner.os` is Linux
+      # for both and Maven artifacts are arch-neutral, so only classifier-based natives
+      # re-download. `-Dnative` also pulls native-image plugins `mvn test` never fetches.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Build native executable (quick build)
         run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob"
@@ -50,8 +64,11 @@ jobs:
           file: docker/Dockerfile.native-package
           tags: floci-oci:test-native
           outputs: type=docker,dest=/tmp/floci-oci-native-image.tar
-          cache-from: type=gha,scope=floci-oci-native
-          cache-to: type=gha,scope=floci-oci-native,mode=max
+          # No layer cache here, deliberately. The COPY below brings in a natively
+          # compiled binary that changes every commit, and Docker layer reuse is
+          # sequential, so nothing after it can ever be reused: the cache was write-only.
+          # `mode=max` still stored the whole image, including that volatile
+          # multi-hundred-MB binary layer, once per PR ref.
 
       - name: Compress native image
         run: gzip /tmp/floci-oci-native-image.tar
@@ -119,8 +136,11 @@ jobs:
           context: compatibility-tests/${{ matrix.test }}
           load: true
           tags: compat-${{ matrix.test }}
+          # Read-only on purpose. Actions caches are ref-scoped, so a pull_request run's
+          # writes land in refs/pull/N/merge, private to that PR: one copy per open PR
+          # overran the repo's cache budget and evicted entries between a PR's own runs.
+          # warm-compat-caches.yml populates these scopes on main; PRs read that one copy.
           cache-from: type=gha,scope=${{ matrix.test }}
-          cache-to: type=gha,scope=${{ matrix.test }},mode=max
 
       - name: Run tests
         id: tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,8 +53,21 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` - it could never hit here. Its restore hashes the pristine
+          # pom.xml, but its post-job save runs *after* `versions:set` below has rewritten
+          # that pom, so the two keys never match. The nightly version embeds the date, so
+          # the save key changed every night: it wrote hundreds of MB per job per night
+          # under a key nothing would ever read.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, keyed identically to ci.yml. This job checks out `ref: main`, so the
+      # pristine pom hashed here matches the one ci.yml hashed. Restoring BEFORE
+      # `versions:set` is load-bearing: after it, the pom hash no longer matches.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Set nightly version
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q
@@ -88,8 +101,21 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` - it could never hit here. Its restore hashes the pristine
+          # pom.xml, but its post-job save runs *after* `versions:set` below has rewritten
+          # that pom, so the two keys never match. The nightly version embeds the date, so
+          # the save key changed every night: it wrote hundreds of MB per job per night
+          # under a key nothing would ever read.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, keyed identically to ci.yml. This job checks out `ref: main`, so the
+      # pristine pom hashed here matches the one ci.yml hashed. Restoring BEFORE
+      # `versions:set` is load-bearing: after it, the pom hash no longer matches.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Set nightly version
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q

--- a/.github/workflows/warm-compat-caches.yml
+++ b/.github/workflows/warm-compat-caches.yml
@@ -1,0 +1,81 @@
+# Populates the buildx layer caches that `compatibility.yml`'s test legs read.
+#
+# Why this exists: GitHub Actions caches are ref-scoped. A pull_request run can
+# READ the base branch's caches but its WRITES land in refs/pull/N/merge, private
+# to that PR. `compatibility.yml` is pull_request-only, so main produced no buildx
+# cache at all: every PR built all five test images cold and wrote its own copy
+# that no other PR could ever read. Measured 2026-08-29, floci-oci held 286 cache
+# entries totalling 3.63 GB, 44% of them per-PR: smaller than its siblings but the
+# same defect, and the same fix keeps it from growing into one.
+#
+# Producing the caches here, on main, means every PR gets a warm read on its FIRST
+# run, and the legs no longer write. Keep this workflow's scope names and runner
+# identical to the ones the legs use, or the warm succeeds and warms nothing.
+#
+# Decision 0015.
+
+name: Warm Compat Caches
+
+on:
+  push:
+    branches: [main]
+    # The dependency-bearing inputs only: the files an image's *expensive* layer is
+    # keyed on. Most legs copy their manifest and install before copying sources, so
+    # a source-only change still reads a warm dependency layer.
+    paths:
+      - 'compatibility-tests/*/Dockerfile'
+      - 'compatibility-tests/*/pom.xml'            # sdk-test-java
+      - 'compatibility-tests/*/requirements.txt'   # sdk-test-python
+      # No wholesale directory watches here: all five legs of this repo's matrix copy
+      # their manifest and install before copying sources, or resolve nothing at build
+      # time beyond what the Dockerfile itself pins (sdk-test-cli, compat-terraform,
+      # compat-opentofu). Checked Dockerfile by Dockerfile, not assumed from a sibling.
+      - '.github/workflows/warm-compat-caches.yml'
+  schedule:
+    # Safety net. Actions evicts caches at 7 days idle and LRU-evicts over budget;
+    # without a periodic producer an evicted main cache would leave every PR cold
+    # indefinitely, and silently.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:        # Manual re-warm after an eviction or a cache purge
+
+permissions:
+  contents: read
+
+concurrency:
+  # A newer main commit supersedes an in-flight warm; never run two at once.
+  group: warm-compat-caches
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: warm / ${{ matrix.test }}
+    # Must match the legs' runner in compatibility.yml. The legs run on arm64, and an
+    # x64 build would write useless x64 layers into the scope they read.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors compatibility.yml's native-compat-test legs exactly.
+        test:
+          - sdk-test-java
+          - sdk-test-python
+          - sdk-test-cli
+          - compat-terraform
+          - compat-opentofu
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          sparse-checkout: compatibility-tests
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and cache test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: compatibility-tests/${{ matrix.test }}
+          # No `load:` - the image itself is discarded; only the cache is wanted.
+          # Scope must stay identical to compatibility.yml's `cache-from`.
+          cache-from: type=gha,scope=${{ matrix.test }}
+          cache-to: type=gha,scope=${{ matrix.test }},mode=max


### PR DESCRIPTION
## Summary

Actions caches are ref-scoped: a `pull_request` run can read the base branch's caches, but its writes land in `refs/pull/N/merge`, private to that PR. Every cache in this repo was written from pull_request jobs, so nothing was ever readable by another run.

Measured 2026-08-29: **286 cache entries totalling 3.63 GB, 44% of them per-PR**. That is the smallest backlog of the four emulators, but it is the same defect and it grows the same way.

Three changes:

- **Maven.** The built-in `cache: maven` never hit here: setup-java's fails to save outright, and nightly's hashes a pom that `versions:set` rewrites before the post-job save. Replaced with explicit `actions/cache` keyed on the root `pom.xml`, restored everywhere and saved from `ci.yml` on pushes to main only, so there is exactly one writer.
- **Compat images.** New `warm-compat-caches.yml` builds the five test images on main and writes their scopes; the pull_request legs now read those scopes and no longer write. A PR gets a warm read on its **first** run, previously impossible.
- **Native package image.** Cache removed outright rather than moved: the image `COPY`s a binary that changes every commit, and Docker layer reuse is sequential, so nothing after it was ever reusable.

`release.yml` and `release-cut.yml` are deliberately untouched: they run rarely and are release-critical, matching the scope floci-aws kept.

This repo needs no wholesale directory watches in the warmer's `paths:` filter: all five matrix legs either copy their manifest and install before copying sources, or pin their expensive layers in the Dockerfile itself. Checked Dockerfile by Dockerfile rather than copied from a sibling, where two legs do need them.

Implements decision 0015. Ported from floci-az ([#245](https://github.com/floci-io/floci-az/pull/245)), where the same change took the repo from 31.83 GB and 100% per-PR entries to **3.15 GB and none**, with all warm legs green on the first run.

### After merge, two manual steps

1. Purge the existing `refs/pull/*` cache entries, or the stale backlog keeps LRU-evicting the new main-scoped cache. Verify with a paginated enumeration of `actions/caches`; the usage endpoint lags deletions badly. Match on `^refs/pull/` rather than just `/merge` — floci-aws also had `/head` entries.
2. `workflow_dispatch` the warmer so the main cache lands in a clean budget.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## OCI Compatibility

n/a — CI configuration only. No emulator code, build inputs, or test logic touched.

## Checklist

- [ ] `mvn test` passes locally — not run; this changes no build input. Gate instead: all workflows parse; no real `cache: maven` key remains in the four touched files (three intentionally remain in `release`/`release-cut`); exactly one `actions/cache/save` repo-wide; the warm producer's scope string and all 5 matrix legs match the compat consumer exactly; both nightly restores precede their `versions:set` steps; `compatibility.yml` writes no caches at all.
- [ ] New or updated integration test added — n/a (CI configuration)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)