### PR TITLE
docs: document the release train and lead with "Any Cloud. Locally."

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent Guide — floci-oci
+# Agent Guide: floci-oci
 
 Guidance for AI coding agents working in the floci-oci repository.
 
@@ -26,7 +26,7 @@ Critical rules:
 
 - Do not introduce custom endpoint shapes
 - Do not change request or response formats for convenience
-- Never invent protocol behavior — consult the reference sources under `local/oracle/`
+- Never invent protocol behavior: consult the reference sources under `local/oracle/`
   (see "OCI Source as Reference" below; `make refs` downloads them)
 
 ## Architecture
@@ -36,26 +36,26 @@ Layered: **Controller** (JAX-RS, parses OCI REST input) → **Service** (busines
 
 Core infrastructure (`io.floci.oci.*`):
 
-- `config/EmulatorConfig` — single `@ConfigMapping(prefix = "floci-oci")` interface
-- `core/common/` — `OciException` + `OciExceptionMapper` (error shape
+- `config/EmulatorConfig`: single `@ConfigMapping(prefix = "floci-oci")` interface
+- `core/common/`: `OciException` + `OciExceptionMapper` (error shape
   `{"code":"...","message":"..."}` + `opc-request-id` header), `ServiceRegistry` +
   `ServiceDescriptor` (self-registering), `ServiceEnabledFilter` (503 for disabled services),
   `RequestContext` (tenancy/user/region)
-- `core/storage/` — `StorageBackend` (memory/persistent/hybrid/wal via `StorageFactory`),
+- `core/storage/`: `StorageBackend` (memory/persistent/hybrid/wal via `StorageFactory`),
   `TenancyAwareStorageBackend` (keys prefixed by tenancy OCID)
-- `core/common/docker/` — sidecar container management
-- `lifecycle/` — `EmulatorLifecycle`, init hooks, `/health` + `/_floci-oci/*` endpoints
+- `core/common/docker/`: sidecar container management
+- `lifecycle/`: `EmulatorLifecycle`, init hooks, `/health` + `/_floci-oci/*` endpoints
 
 ## OCI Protocol Rules
 
 - Every service except Object Storage uses a date-versioned path prefix
   (Identity `/20160918/…`); Object Storage uses `/n/{namespace}/b/{bucket}/o/{object}`.
-  JAX-RS `@Path` matching dispatches directly — there is no routing filter.
+  JAX-RS `@Path` matching dispatches directly: there is no routing filter.
 - Errors: `{"code": "...", "message": "..."}` body + correct HTTP status. 404 is
   `NotAuthorizedOrNotFound` (OCI deliberately conflates the two).
 - Every response carries an `opc-request-id` header.
 - Pagination: `limit`/`page` query params in, `opc-next-page` response header out.
-  Some list APIs return a bare JSON array — verify each against the SDK model.
+  Some list APIs return a bare JSON array: verify each against the SDK model.
 - OCIDs: `ocid1.<type>.<realm>.<region>.<unique>` (region omitted for global resources).
 - Auth: the `Authorization: Signature …` header is parsed for tenancy/user context only;
   the RSA signature is never verified.
@@ -83,7 +83,7 @@ metadata through descriptors. Adding a service must never require editing a swit
 ## Services with Container Sidecars
 
 Some services launch real Docker containers (sidecars). **`services/functions/` is the
-reference implementation** — copy its shape:
+reference implementation**: copy its shape:
 
 1. **One `mock()` flag is the only container toggle** on the service's config
    (`@WithDefault("false")`, env `FLOCI_OCI_SERVICES_<SVC>_MOCK`). No separate opt-in.
@@ -92,22 +92,22 @@ reference implementation** — copy its shape:
 2. **The Manager (driver) is flag-free** and owns only mechanics: lazy idempotent
    `ensureStarted()` (self-healing via `isContainerRunning`), a single cheap
    `boolean isReady()` probe, `stop()`. It goes through `ContainerBuilder` /
-   `ContainerLifecycleManager` — never raw `dockerClient` calls — and MUST
+   `ContainerLifecycleManager`, never raw `dockerClient` calls, and MUST
    `portAllocator.release(port)` in the stop path (leaked ports exhaust the range).
 3. **The service owns the gate**: every container interaction sits behind `!mock()`;
    mock mode keeps the management plane fully usable with synthetic data-plane results.
-4. **Never block a request thread on readiness** — poll asynchronously or bound the wait
+4. **Never block a request thread on readiness**: poll asynchronously or bound the wait
    to the data-plane call that actually needs the sidecar (Functions bounds it to invoke).
 5. **Teardown**: `@PreDestroy` stops the sidecar, and the service implements
    `Resettable` so `POST /_floci-oci/state/reset` also removes containers/volumes.
 6. **Tests**: the standard trio runs in mock mode; add a `<Svc>DockerTest` with
    `@TestProfile` flipping `mock=false`, `assumeTrue(docker socket)` in `@BeforeAll`,
-   `PER_CLASS` + ordered methods, and a final cleanup test (not `@AfterAll` — the
+   `PER_CLASS` + ordered methods, and a final cleanup test (not `@AfterAll`, because the
    server port is gone by then).
 7. Container/volume names go through `ContainerStorageHelper.dockerName()`.
 
 Fn-specific: fnserver shares its iofs unix-socket directory with function containers via
-a **named volume** (`FN_IOFS_DOCKER_PATH=<volumeName>`) — host bind mounts break unix
+a **named volume** (`FN_IOFS_DOCKER_PATH=<volumeName>`): host bind mounts break unix
 sockets on Docker Desktop. Old `fnproject/hello` images predate the http-stream FDK
 contract; use a current FDK image (see `src/test/resources/fn-hello/`).
 
@@ -168,7 +168,7 @@ contract; use a current FDK image (see `src/test/resources/fn-hello/`).
 
 ## OCI Source as Reference
 
-Never invent protocol behavior — verify request/response shapes, field casing, headers,
+Never invent protocol behavior. Verify request/response shapes, field casing, headers,
 status codes and enums against the real OCI sources before implementing anything.
 Do not read jars from `~/.m2` as protocol reference.
 
@@ -177,16 +177,16 @@ fetch or refresh them all with `make refs`):
 
 | Checkout | Use it for |
 |---|---|
-| `local/oracle/oci-go-sdk` | **Primary wire model.** Generated Go structs carry `json:"…"` tags, `mandatory:"true"`, enum constants, and `*_request_response.go` files declare every request/response header (`presentIn:"header"`) and body shape (`presentIn:"body"` — bare-array lists, binary bodies). `*_client.go` has the exact method + path per operation and the client `BasePath` (API version prefix). |
+| `local/oracle/oci-go-sdk` | **Primary wire model.** Generated Go structs carry `json:"…"` tags, `mandatory:"true"`, enum constants, and `*_request_response.go` files declare every request/response header (`presentIn:"header"`) and body shape (`presentIn:"body"`, covering bare-array lists and binary bodies). `*_client.go` has the exact method + path per operation and the client `BasePath` (API version prefix). |
 | `local/oracle/oci-java-sdk` | Cross-check for the Go model, and the client used by the default compat suite. Prefer the Go model on any disagreement. |
-| `local/oracle/oci-python-sdk` | Python client behavior — e.g. `UploadManager`'s multipart flow, which required `opc-content-md5` on UploadPart responses. |
+| `local/oracle/oci-python-sdk` | Python client behavior, e.g. `UploadManager`'s multipart flow, which required `opc-content-md5` on UploadPart responses. |
 | `local/oracle/oci-typescript-sdk` | TypeScript client cross-check. |
 | `local/oracle/oci-cli` | CLI-level behavior and parameter mapping (generated from the same specs). |
 | `local/oracle/terraform-provider-oci` | Exactly which API calls and read-backs IaC performs. Bucket Read calling `ListRetentionRules` came from here. Client-name keys for `CLIENT_HOST_OVERRIDES` are the `RegisterOracleClient` names in `internal/client/*.go`. |
 
 Precedence when sources disagree: **oci-go-sdk → oci-java-sdk → published API reference**.
 There is no botocore equivalent and no reference implementation (no LocalStack/moto/Azurite
-analog) — the generated SDK models are the closest thing OCI has to a wire contract.
+analog): the generated SDK models are the closest thing OCI has to a wire contract.
 
 Typical lookups:
 
@@ -204,4 +204,4 @@ grep -n 'func (s \*.*ResourceCrud) Get' local/oracle/terraform-provider-oci/inte
 ## Do not
 
 - Do not execute `git add` or `git commit`; do not commit any changes
-- Do not read jars from `~/.m2` as protocol reference — use `local/oracle/` checkouts
+- Do not read jars from `~/.m2` as protocol reference: use `local/oracle/` checkouts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ contract; use a current FDK image (see `src/test/resources/fn-hello/`).
 - Self-explanatory code over comments; always use braces
 - JBoss Logging, structured, no noise in hot paths
 
+## Documentation Style
+
+- No em-dashes anywhere, in any content. Use colons, commas, or periods.
+
 ## Pull Request Guidelines
 
 - Conventional commits: `feat:`, `fix:`, `perf:`, `docs:`, `chore:`

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ config at real OCI.
 
 ### Release train
 
-Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-oci:nightly` tracks `main`. Every merged fix is available the next day, with immutable `nightly-mmddyyyy` tags for reproducible builds.
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-oci:nightly` tracks `main`. Every merged fix is available the next day, and dated `nightly-mmddyyyy` tags let you pin a specific night's build.
 
 Versions are derived from Conventional Commits by [semantic-release](https://github.com/semantic-release/semantic-release); `CHANGELOG.md` is generated, never hand-edited. Releases are cut from `main` only: there are no maintenance branches.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 </p>
 
 <p align="center">
-  <strong>Light, fluffy, and always free — now for Oracle Cloud</strong><br />
+  <strong>Any Cloud. Locally.</strong><br />
+  Light, fluffy, and always free, now for Oracle Cloud<br />
   No account. No API key ceremony. No feature gates. Just <code>docker compose up</code>.
 </p>
 
@@ -34,7 +35,7 @@ floci-oci is a free, open-source local **Oracle Cloud Infrastructure (OCI)** emu
 
 It gives you OCI-shaped services on your machine without an Oracle Cloud account, uploaded API keys, or paid feature gates. Point the OCI SDKs, the OCI CLI, Terraform, or OpenTofu at `http://localhost:4599` and keep your existing workflows.
 
-floci-oci is the OCI member of the [Floci](https://github.com/floci-io) emulator family — named after [floccus](https://en.wikipedia.org/wiki/Cirrocumulus_floccus), the cloud formation that looks like popcorn.
+floci-oci is the OCI member of the [Floci](https://github.com/floci-io) emulator family, named after [floccus](https://en.wikipedia.org/wiki/Cirrocumulus_floccus), the cloud formation that looks like popcorn.
 
 | Emulator                                                           | Cloud | Port |
 |--------------------------------------------------------------------|---|:---:|
@@ -74,7 +75,7 @@ oci iam compartment list --endpoint http://localhost:4599 \
   --compartment-id ocid1.tenancy.oc1..flocilocaltenancy0000000000000000000000000000000000000000
 ```
 
-Any locally generated API key works — floci-oci parses the request signature for tenancy and user context but never verifies it. See [OCI CLI & SDK Setup](https://floci.io/floci-oci/getting-started/oci-setup/) for a one-time throwaway config.
+Any locally generated API key works: floci-oci parses the request signature for tenancy and user context but never verifies it. See [OCI CLI & SDK Setup](https://floci.io/floci-oci/getting-started/oci-setup/) for a one-time throwaway config.
 
 <details>
 <summary>Prefer building from source?</summary>
@@ -127,7 +128,7 @@ Real request and response shapes: `opc-request-id` on every response, `opc-next-
 <details>
 <summary><strong>Drop-in SDK, CLI, and IaC compatibility</strong></summary>
 
-The official oci-java-sdk, Python SDK, OCI CLI, and the `oracle/oci` Terraform provider work unchanged — validated continuously by the [compatibility suite](#compatibility-testing).
+The official oci-java-sdk, Python SDK, OCI CLI, and the `oracle/oci` Terraform provider work unchanged, validated continuously by the [compatibility suite](#compatibility-testing).
 
 </details>
 
@@ -147,7 +148,7 @@ Choose from in-memory, persistent, hybrid, and write-ahead log storage depending
 
 ## Why floci-oci?
 
-Oracle Cloud has no official local emulator — no LocalStack equivalent, no all-in-one dev container. Testing OCI integrations means a real tenancy, real credentials, and real network round-trips, even in CI.
+Oracle Cloud has no official local emulator: no LocalStack equivalent, no all-in-one dev container. Testing OCI integrations means a real tenancy, real credentials, and real network round-trips, even in CI.
 
 floci-oci fills that gap the same way its siblings do for AWS, Azure, and GCP: one container, one port, real wire protocols, MIT licensed, free forever.
 
@@ -207,7 +208,7 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | Queue | In-process | Work-request-driven control plane (mutations return no body); data plane with visibility timeouts, `0`-visibility peeks, long polling, dead-letter queues, per-channel filtering, stats; wrapped `{"items":[…]}` list shape |
 | Streaming | In-process | Partitioned append-only log with key-hash placement; opaque cursors (`TRIM_HORIZON`/`LATEST`/`AT_OFFSET`/`AFTER_OFFSET`/`AT_TIME`), group cursors with commit + resume, `opc-next-cursor` paging; CreateStream returns body *and* work request |
 | Vault + KMS | In-process, real crypto | Vaults and keys with schedule/cancel deletion (no DELETE verb), key rotation; AES-GCM encrypt/decrypt whose envelope survives rotation, RSA/ECDSA sign/verify via JCA, CRC32 `plaintextChecksum` |
-| Secrets | In-process | Secret versions with CURRENT/PREVIOUS/LATEST stages; the `Secret` shape never echoes content — retrieval is through `/20190301/secretbundles`, including the bodyless POST `getByName` |
+| Secrets | In-process | Secret versions with CURRENT/PREVIOUS/LATEST stages; the `Secret` shape never echoes content: retrieval is through `/20190301/secretbundles`, including the bodyless POST `getByName` |
 | Functions | Real Docker (Fn Project) | Applications and functions with deterministic image digests; invocation proxied to a shared `fnproject/fnserver` sidecar that runs your real FDK image. `mock: true` disables Docker entirely |
 | OKE (Container Engine) | Real Docker (k3s) / In-process | Control plane CRUD (`/20180222`), options, kubeconfig YAML generator, work requests tracking; real-mode k3s sidecar driver (`rancher/k3s:v1.30.1-k3s1`) binding dynamic host ports (`6443..6543`) and persistent volumes (`/var/lib/rancher/k3s`). `mock: true` disables sidecar |
 | Work Requests | In-process | `202` + `opc-work-request-id` responses, pollable per service (`/20160918`, `/20210201`, `/20180418`, `/20180222` and unversioned `/workRequests`) with errors/logs endpoints |
@@ -222,7 +223,7 @@ floci-oci runs a real container where in-process emulation would not be faithful
 
 | Service | Default image | What is real |
 |---|---|---|
-| Functions | `fnproject/fnserver:latest` | The open-source engine OCI Functions is built on. Your function image runs for real — fnserver spawns it as a sibling container and speaks the FDK http-stream contract |
+| Functions | `fnproject/fnserver:latest` | The open-source engine OCI Functions is built on. Your function image runs for real: fnserver spawns it as a sibling container and speaks the FDK http-stream contract |
 | OKE | `rancher/k3s:v1.30.1-k3s1` | Real local Kubernetes cluster execution via a k3s sidecar container with dynamic host port mapping (`6443..6543`) and named data volume `/var/lib/rancher/k3s` |
 
 Docker-backed services need the Docker socket:
@@ -234,7 +235,7 @@ docker run -d --name floci-oci \
   floci/floci-oci:latest
 ```
 
-Set `FLOCI_OCI_SERVICES_FUNCTIONS_MOCK=true` or `FLOCI_OCI_SERVICES_OKE_MOCK=true` to skip Docker entirely — the management
+Set `FLOCI_OCI_SERVICES_FUNCTIONS_MOCK=true` or `FLOCI_OCI_SERVICES_OKE_MOCK=true` to skip Docker entirely. The management
 plane stays fully usable and invocations/cluster records return synthetic data. That is the default in
 the test suite, so `./mvnw test` never needs a Docker daemon.
 
@@ -259,7 +260,7 @@ For more detail, see the [Storage Configuration documentation](https://floci.io/
 
 ## Multi-Tenancy Isolation
 
-floci-oci supports per-tenancy resource isolation with no extra setup. The tenancy OCID in your signing key's `keyId` is the storage partition — requests signed with different tenancy OCIDs see fully isolated resources.
+floci-oci supports per-tenancy resource isolation with no extra setup. The tenancy OCID in your signing key's `keyId` is the storage partition: requests signed with different tenancy OCIDs see fully isolated resources.
 
 ```bash
 # Two profiles with different tenancy OCIDs see independent worlds
@@ -267,11 +268,11 @@ oci --profile TENANCY_A iam user list --endpoint http://localhost:4599
 oci --profile TENANCY_B iam user list --endpoint http://localhost:4599
 ```
 
-Unsigned requests fall back to `FLOCI_OCI_DEFAULT_TENANCY_ID`. Compartments are a field on each resource (filtered via `compartmentId`), exactly as on real OCI — tenancy is the isolation boundary, compartments are the organizational one.
+Unsigned requests fall back to `FLOCI_OCI_DEFAULT_TENANCY_ID`. Compartments are a field on each resource (filtered via `compartmentId`), exactly as on real OCI. Tenancy is the isolation boundary, compartments are the organizational one.
 
 ## SDK Integration
 
-Point your existing OCI SDK at `http://localhost:4599`. Any locally generated RSA key works — the signature is parsed for tenancy/user context, never verified.
+Point your existing OCI SDK at `http://localhost:4599`. Any locally generated RSA key works: the signature is parsed for tenancy/user context, never verified.
 
 <details>
 <summary><strong>Java, oci-java-sdk</strong></summary>
@@ -393,7 +394,7 @@ oci --profile FLOCI os ns get --endpoint http://localhost:4599
 
 ## Terraform and OpenTofu
 
-The official `oracle/oci` provider works against floci-oci through its per-client host overrides — no provider fork, no wrapper:
+The official `oracle/oci` provider works against floci-oci through its per-client host overrides, with no provider fork and no wrapper:
 
 ```bash
 export TF_VAR_CLIENT_HOST_OVERRIDES="oci_identity.IdentityClient=http://localhost:4599;oci_object_storage.ObjectStorageClient=http://localhost:4599"
@@ -419,7 +420,7 @@ The full apply → plan (zero drift) → destroy cycle is validated in CI for bo
 
 ## Compatibility Testing
 
-The [`compatibility-tests`](./compatibility-tests/) directory validates floci-oci with real SDKs and IaC tooling — not just theoretical protocol adherence.
+The [`compatibility-tests`](./compatibility-tests/) directory validates floci-oci with real SDKs and IaC tooling, not just theoretical protocol adherence.
 
 | Module | Language / Tool | SDK / Client | Tests |
 |---|---|---|---:|
@@ -476,9 +477,15 @@ docker exec floci-oci ocilocal os ns get
 ```
 
 `ocilocal` is a thin wrapper that points `oci` at the emulator. The bundled key exists
-only because the OCI CLI refuses to run without one — floci-oci parses request
+only because the OCI CLI refuses to run without one. floci-oci parses request
 signatures but never verifies them, so the key is public by design. Never point that
 config at real OCI.
+
+### Release train
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Between trains, `floci/floci-oci:nightly` tracks `main`. Every merged fix is available the next day, with immutable `nightly-mmddyyyy` tags for reproducible builds.
+
+Versions are derived from Conventional Commits by [semantic-release](https://github.com/semantic-release/semantic-release); `CHANGELOG.md` is generated, never hand-edited. Releases are cut from `main` only: there are no maintenance branches.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Implements hub decision 0017. Documentation only, no behavior change.

- **Release train.** States the stable cadence, the 1st and 3rd Tuesday of each month, at the end of `## Image Tags`, with the nightly channel as the between-trains answer. The cadence appeared in no README, docs page, `CONTRIBUTING.md` or workflow, so an evaluator reading the releases page saw a release count with no schedule behind it.
- **Tagline.** Promotes "Any Cloud. Locally." to the header. The four-cloud family table this repo already carries is the pattern the other three now copy, so the table itself is unchanged.
- **Punctuation.** Replaces every em-dash with ordinary punctuation and records the rule in `AGENTS.md`, matching the convention already set for community content.

No new top-level heading: `### Release train` is an `h3` inside `## Image Tags`, so the `##` count is unchanged at 19 and every nav anchor still resolves.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## OCI Compatibility

Not applicable. No source, wire protocol, or workflow is touched.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
