### PR TITLE
docs: use x.y.z in the pinned image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ image: floci/floci-oci:latest
 image: floci/floci-oci:latest-compat
 
 # Pinned release
-image: floci/floci-oci:0.1.0
+image: floci/floci-oci:x.y.z
 
 # Track main
 image: floci/floci-oci:nightly


### PR DESCRIPTION
## Summary

The README's compose example pinned `0.1.0`. Current is `0.3.0`, so the example was stale, and every emulator README had the same problem for the same reason: a concrete version in a doc nobody re-edits at release time.

It now reads `x.y.z`, which is already how the channel table directly above the example writes the pinned channel. The snippet finally agrees with its own table and cannot go stale again.

**The tradeoff, stated plainly:** `image: floci/[image]:x.y.z` is not copy-pasteable. The line above it, `image: floci/[image]:latest`, is, and it is the recommended one, so the pinned line reads as the pattern rather than a runnable default. That is the deliberate choice here.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## OCI Compatibility

Not applicable. Documentation only.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
