### PR TITLE
ci: raise the Release Cut timeout to 60 minutes

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -45,7 +45,9 @@ jobs:
   release:
     name: Cut release from main
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # semantic-release comments on and labels every issue and PR in the release,
+    # which is roughly two API writes each. A 278-PR release took ~22 minutes.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Raises `timeout-minutes` on the Release Cut job from `15` to `60`.

**This repo has never timed out**; its release cuts finish in one to four minutes. The value is raised anyway so all four emulator workflows stay identical, which is how they have been maintained since the one-button release work.

**The cancelled releases actually succeeded.** 2.0.0 was tagged 38 seconds into the semantic-release step; `chore(release): 2.0.0` is on `main`, `pom.xml` reads 2.0.0, the CHANGELOG section is written, and the GitHub Release exists. Only the post-publish work was killed, so the cost was a red run and the doubt that follows it, not a broken release. Worth knowing before treating a cancelled Release Cut as a failed release.

### Why it runs long

Duration tracks the number of PRs in the release, not repo size or runner speed:

| Release | PR refs in range | Outcome |
|---|---|---|
| floci 1.5.34 to 1.6.0 | 58 | success, 5m27s |
| floci 1.6.0 to 1.7.0 | 167 | cancelled at 15m |
| floci 1.7.0 to 2.0.0 | 278 | cancelled at 15m |
| floci-oci 0.2.0 to 0.3.0 | 5 | success, 1m20s |

`@semantic-release/github` posts a `successComment` on every issue and PR in the release **and** adds a `released` label to each, both enabled by default. A 278-PR release is therefore roughly 556 API writes, which at the observed rate is about 22 minutes. All four `.releaserc.json` are byte-identical, which is why this only bites the busiest repo.

### Why 60 and not 30

There is no batching or throttle option in `@semantic-release/github` 11.0.6 (the pinned version) and no bulk-comment endpoint in the GitHub API, so the choice is between dropping the comments and allowing the time. The comments are worth keeping. 278 PRs already needs about 22 minutes, so 30 would be back at the wall within a release or two.

If a future release does pass 60 minutes, the levers are `successCommentCondition: "<% return !issue.pull_request; %>"` to comment on issues only, or `releasedLabels: false`. Both trade a contributor-facing signal for time, which is why neither is taken here.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## OCI Compatibility

Not applicable. Workflow configuration only; no source, wire protocol, or published artifact changes.

## Checklist

- [x] Tests pass locally (not run: no source changed)
- [ ] New or updated integration test added (not applicable)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<sub>Cannot be verified until the next release cut: the change only proves itself when a large release runs green end to end.</sub>
